### PR TITLE
React to the current nick instead of the configured nick

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ var lastmsg = "";
 let commands = [
   {
     trigger: message => (message.startsWith("!g") ||
-                         message.startsWith(process.env.NICK || "gb3")),
+                         message.startsWith(client.nick)),
     handler: handle_google,
   },
   {


### PR DESCRIPTION
The current nick could be different if the configured nick is already taken or if the bot gets renamed by `NickServ`.